### PR TITLE
Remove old Topic support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove old Topic support.
+  [bsuttor]
 
 
 2.3.4 (2014-08-08)

--- a/Solgema/fullcalendar/profiles/default/types/Topic.xml
+++ b/Solgema/fullcalendar/profiles/default/types/Topic.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<object name="Topic"
-   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n" purge="False">
- <property name="view_methods" purge="False">
-  <element value="solgemafullcalendar_view" i18n:domain="Solgema.fullcalendar"/>
- </property>
-</object>


### PR DESCRIPTION
I had trouble with installation of Solgema fullcalendar on Plone 4.3.x with plone.app.contenttypes 1.1.x.
Indeed there is no more Topic on Dexterity content types.

Topic became old, so I think we can just remove support of it