### PR TITLE
Add dexterity folder and collection view for plone 43 with plone.app.contenttypes 1.1.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add new Dexterity folder view herited from FolderView (plone.app.contenttypes.browser.folder).
+  [bsuttor]
 
 
 2.3.4 (2014-08-08)

--- a/Solgema/fullcalendar/browser/configure.zcml
+++ b/Solgema/fullcalendar/browser/configure.zcml
@@ -33,7 +33,7 @@
   <browser:page
       for="plone.app.contenttypes.interfaces.IFolder"
       name="solgemafullcalendar_view"
-      class=".views.SolgemaFullcalendarView"
+      class=".views.SolgemaFullcalendarDxView"
       template="folderview.pt"
       allowed_interface="Solgema.fullcalendar.interfaces.ISolgemaFullcalendarView"
       permission="zope.Public"
@@ -489,36 +489,36 @@
     factory=".adapters.SolgemaFullcalendarEventDict" />
 
   <adapter factory=".adapters.FolderColorIndexGetter"/>
-  <adapter 
+  <adapter
     zcml:condition="installed plone.app.contenttypes"
     factory=".adapters.DXFolderColorIndexGetter"/>
   <adapter factory=".adapters.ColorIndexGetter"/>
-  
+
   <!-- IEventSource adapters -->
   <adapter factory=".adapters.FolderEventSource"/>
-  <adapter 
+  <adapter
     zcml:condition="installed plone.app.contenttypes"
     factory=".adapters.DXFolderEventSource"/>
   <adapter factory=".adapters.TopicEventSource"/>
   <adapter factory=".adapters.CollectionEventSource"/>
-  <adapter 
+  <adapter
     zcml:condition="installed plone.app.contenttypes"
     factory=".adapters.DXCollectionEventSource"/>
   <adapter factory=".adapters.StandardEventSource"/>
-    
+
   <adapter factory=".adapters.listCriteriasTopicAdapter"/>
   <adapter factory=".adapters.listCriteriasCollectionAdapter"/>
-  <adapter 
+  <adapter
     zcml:condition="installed plone.app.contenttypes"
     factory=".adapters.listCriteriasDXCollectionAdapter"/>
   <adapter factory=".adapters.listBaseQueryTopicCriteria"/>
   <adapter factory=".adapters.listBaseQueryCollectionCriteria"/>
-  <adapter 
+  <adapter
     zcml:condition="installed plone.app.contenttypes"
     factory=".adapters.listBaseQueryDXCollectionCriteria"/>
   <adapter factory=".adapters.CriteriaItemsTopic"/>
   <adapter factory=".adapters.CriteriaItemsCollection"/>
-  <adapter 
+  <adapter
     zcml:condition="installed plone.app.contenttypes"
     factory=".adapters.CriteriaItemsDXCollection"/>
 

--- a/Solgema/fullcalendar/browser/views.py
+++ b/Solgema/fullcalendar/browser/views.py
@@ -14,7 +14,6 @@ from zope.component.hooks import getSite
 from zope.i18nmessageid import MessageFactory
 from zope.schema.interfaces import IVocabularyFactory
 from plone.i18n.normalizer.interfaces import IURLNormalizer
-
 from Products.Five import BrowserView
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneLocalesMessageFactory as PLMF
@@ -23,6 +22,7 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.ATContentTypes.interface import IATFolder
 try:
     from plone.app.contenttypes.behaviors.collection import ICollection
+    from plone.app.contenttypes.browser.folder import FolderView
     COLLECTION_IS_BEHAVIOR = False
 except ImportError:
     COLLECTION_IS_BEHAVIOR = True
@@ -169,6 +169,16 @@ class SolgemaFullcalendarView(BrowserView):
         return '%s/solgemafullcalendar_vars.js%s' % (base_url, query)
 
 
+class SolgemaFullcalendarDxView(FolderView, SolgemaFullcalendarView):
+    """Solgema Fullcalendar Browser view for Fullcalendar rendering."""
+
+    implements(interfaces.ISolgemaFullcalendarView)
+
+    def __init__(self, context, request):
+        super(SolgemaFullcalendarDxView, self).__init__(context, request)
+        self.calendar = interfaces.ISolgemaFullcalendarProperties(aq_inner(context), None)
+
+
 class SolgemaFullcalendarTopicView(SolgemaFullcalendarView):
     """Solgema Fullcalendar Browser view for Fullcalendar rendering"""
 
@@ -193,6 +203,7 @@ class SolgemaFullcalendarTopicView(SolgemaFullcalendarView):
         return False
 
 
+
 class SolgemaFullcalendarCollectionView(SolgemaFullcalendarView):
     """Solgema Fullcalendar Browser view for Fullcalendar rendering"""
 
@@ -210,7 +221,7 @@ class SolgemaFullcalendarCollectionView(SolgemaFullcalendarView):
         return self.request.cookies.get('sfqueryDisplay', listCriteria[0])
 
 
-class SolgemaFullcalendarDXCollectionView(SolgemaFullcalendarView):
+class SolgemaFullcalendarDXCollectionView(SolgemaFullcalendarDxView):
     """Solgema Fullcalendar Browser view for Fullcalendar rendering"""
 
     def results(self, **kwargs):


### PR DESCRIPTION
plone.app.contenttypes 1.1.x is the version used in Plone 4.3.x.
At this moment, Solgema.fullcalendar (Collection and Folder) views didn't work.
This PR fix that 